### PR TITLE
fix: add command for setup edge case

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -66,6 +66,7 @@ Once you've installed `uv`, you can use it to install the Python libraries into 
 
 2. Install the libraries:
    ```bash
+   courses/open-energy-data-for-all/ % uv python install
    courses/open-energy-data-for-all/ % uv sync
    ```
 


### PR DESCRIPTION
I only had Python 3.13 on my machine, which satisfies the pyproject.toml >=3.12 requirement. But a library required <3.13, and then uv got confused. `uv install python` will actually install the version of Python that fits all of the requirements instead of merely looking to see if any that work already exist on your system.
